### PR TITLE
fix OneToMany::load

### DIFF
--- a/src/Association/OneToMany.php
+++ b/src/Association/OneToMany.php
@@ -43,7 +43,7 @@ class OneToMany extends Multi
             [],
             $this->orderBy,
             $this->limit,
-            $this->offse
+            $this->offset   // TODO: typo
         );
 
         // Set target conditions
@@ -51,7 +51,7 @@ class OneToMany extends Multi
         $conditions[] = [
             $this->getReferencedKey(),
             "IN",
-            array_keys($primaryValues),
+            array_values($primaryValues), // TODO: no array_keys but array_values
             "AND"
         ];
         $query->setConditions($conditions);
@@ -62,7 +62,12 @@ class OneToMany extends Multi
             return [];
         }
 
-        return $result;
+        $return = [];
+        foreach ($result as $row) {
+            $return[$row[$this->getReferencedKey()]][] = $row;
+        }
+
+        return $return;
     }
 
 }

--- a/src/Association/OneToMany.php
+++ b/src/Association/OneToMany.php
@@ -43,7 +43,7 @@ class OneToMany extends Multi
             [],
             $this->orderBy,
             $this->limit,
-            $this->offset   // TODO: typo
+            $this->offset
         );
 
         // Set target conditions
@@ -51,7 +51,7 @@ class OneToMany extends Multi
         $conditions[] = [
             $this->getReferencedKey(),
             "IN",
-            array_values($primaryValues), // TODO: no array_keys but array_values
+            array_values($primaryValues),
             "AND"
         ];
         $query->setConditions($conditions);

--- a/tests/Fixtures/Entity/Simple.php
+++ b/tests/Fixtures/Entity/Simple.php
@@ -26,6 +26,8 @@ Reflection\Property::registerAssocFilter("textLikeFoo", function (Assoc\Single $
  * @property      integer  $mark
  * @property      Nested   $entity
  * @property      Nested[] $collection  m:assoc(M:N) m:assoc-by(simpleId|simple_nested|nestedId)
+ * @property      Nested[] $oneToMany   m:assoc(1:N) m:assoc-by(simplePrimaryId)
+ * @property      Remote[] $oneToManyRemote m:assoc(1:N) m:assoc-by(simplePrimaryId)
  * @property      Remote[] $manyToMany  m:assoc(M:N) m:assoc-by(simpleId|simple_remote|remoteId)
  * @property      Remote[] $mmFilter    m:assoc(M:N) m:assoc-by(simpleId|simple_remote|remoteId) m:assoc-filter-sortAndLimit(DESC|10)
  * @property      Remote   $manyToOne   m:assoc(N:1) m:assoc-by(remoteId)

--- a/tests/cases/Entity.phpt
+++ b/tests/cases/Entity.phpt
@@ -121,7 +121,7 @@ class EntityTest extends \Tester\TestCase
         $this->entity->entity = new Fixtures\Entity\Nested;
 
         Assert::type("array", $this->entity->toArray());
-        Assert::count(20, $this->entity->toArray());
+        Assert::count(22, $this->entity->toArray());
         Assert::same("test", $this->entity->toArray()["text"]);
         Assert::same("", $this->entity->toArray()["empty"]);
         Assert::same($this->entity->collection, $this->entity->toArray()["collection"]);
@@ -163,6 +163,8 @@ class EntityTest extends \Tester\TestCase
                         'publicProperty' => 'defaultValue'
                     ),
                 ),
+                'oneToMany' => array(),
+                'oneToManyRemote' => array(),
                 'manyToMany' => array(array('id' => 1, 'manyToManyNoDominance' => array(), 'text' => NULL)),
                 'mmFilter' => array(),
                 'manyToOne' => NULL,
@@ -189,7 +191,7 @@ class EntityTest extends \Tester\TestCase
     public function testJsonSerializable()
     {
         Assert::same(
-            '{"id":1,"text":"test","empty":"","url":null,"email":null,"time":null,"year":null,"ip":null,"mark":null,"entity":null,"collection":[],"manyToMany":[],"mmFilter":[],"manyToOne":null,"oneToOne":null,"ooFilter":null,"readonly":null,"storedData":null,"enumeration":null,"publicProperty":"defaultValue"}',
+            '{"id":1,"text":"test","empty":"","url":null,"email":null,"time":null,"year":null,"ip":null,"mark":null,"entity":null,"collection":[],"oneToMany":[],"oneToManyRemote":[],"manyToMany":[],"mmFilter":[],"manyToOne":null,"oneToOne":null,"ooFilter":null,"readonly":null,"storedData":null,"enumeration":null,"publicProperty":"defaultValue"}',
             json_encode($this->entity)
         );
     }
@@ -334,6 +336,8 @@ class EntityTest extends \Tester\TestCase
             'mark',
             'entity',
             'collection',
+            'oneToMany',
+            'oneToManyRemote',
             'manyToMany',
             'mmFilter',
             'manyToOne',

--- a/tests/cases/EntityCollection.phpt
+++ b/tests/cases/EntityCollection.phpt
@@ -94,7 +94,7 @@ class EntityCollectionTest extends \Tester\TestCase
 
         $collection[] = new Fixtures\Entity\Simple(["id" => 1]);
         Assert::same(
-            '[{"id":1,"text":null,"empty":null,"url":null,"email":null,"time":null,"year":null,"ip":null,"mark":null,"entity":null,"collection":[],"manyToMany":[],"mmFilter":[],"manyToOne":null,"oneToOne":null,"ooFilter":null,"readonly":null,"storedData":null,"enumeration":null,"publicProperty":"defaultValue"}]',
+            '[{"id":1,"text":null,"empty":null,"url":null,"email":null,"time":null,"year":null,"ip":null,"mark":null,"entity":null,"collection":[],"oneToMany":[],"oneToManyRemote":[],"manyToMany":[],"mmFilter":[],"manyToOne":null,"oneToOne":null,"ooFilter":null,"readonly":null,"storedData":null,"enumeration":null,"publicProperty":"defaultValue"}]',
             json_encode($collection)
         );
     }

--- a/tests/cases/Reflection.Entity.phpt
+++ b/tests/cases/Reflection.Entity.phpt
@@ -62,6 +62,8 @@ class ReflectionEntityTest extends \Tester\TestCase
                 'mark',
                 'entity',
                 'collection',
+                'oneToMany',
+                'oneToManyRemote',
                 'manyToMany',
                 'mmFilter',
                 'manyToOne',


### PR DESCRIPTION
typos, empty $primaryValues checking, return result in assoc array by primaryValues