### PR TITLE
Added support for joins in filters

### DIFF
--- a/src/Adapter/IQueryWithJoins.php
+++ b/src/Adapter/IQueryWithJoins.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace UniMapper\Adapter;
+
+
+interface IQueryWithJoins
+{
+
+    public function setJoins(array $joins);
+
+}

--- a/src/Adapter/Mapping.php
+++ b/src/Adapter/Mapping.php
@@ -2,6 +2,7 @@
 
 namespace UniMapper\Adapter;
 
+use UniMapper\Entity\Reflection;
 use UniMapper\Entity\Reflection\Property;
 
 abstract class Mapping
@@ -15,6 +16,16 @@ abstract class Mapping
     public function unmapValue(Property $property, $value)
     {
         return $value;
+    }
+    
+    public function unmapFilterJoins(Reflection $reflection, array $filter)
+    {
+        return [];
+    }
+    
+    public function unmapFilterJoinProperty(Reflection $reflection, $name)
+    {
+        return $name;
     }
 
 }

--- a/src/Association.php
+++ b/src/Association.php
@@ -20,6 +20,12 @@ abstract class Association
     /** @var string */
     protected $propertyName;
 
+    /** @var  array */
+    protected $targetSelection = [];
+
+    /** @var array array */
+    protected $targetFilter = [];
+
     public function __construct(
         $propertyName,
         Entity\Reflection $sourceReflection,
@@ -93,6 +99,26 @@ abstract class Association
     public function getPropertyName()
     {
         return $this->propertyName;
+    }
+
+    public function getTargetSelection()
+    {
+        return $this->targetSelection;
+    }
+
+    public function setTargetSelection(array $targetSelection)
+    {
+        $this->targetSelection = $targetSelection;
+    }
+
+    public function getTargetFilter()
+    {
+        return $this->targetFilter;
+    }
+
+    public function setTargetFilter(array $filter)
+    {
+        $this->targetFilter = $filter;
     }
 
     /**

--- a/src/Association/ManyToMany.php
+++ b/src/Association/ManyToMany.php
@@ -111,7 +111,7 @@ class ManyToMany extends Multi
 
         $targetQuery = $targetAdapter->createSelect(
             $this->getTargetResource(),
-            [],
+            $this->getTargetSelection(),
             $this->orderBy,
             $this->limit,
             $this->offset
@@ -120,6 +120,9 @@ class ManyToMany extends Multi
         // Set target conditions
         $filter = $this->filter;
         $filter[$this->getTargetPrimaryKey()][Entity\Filter::EQUAL] = array_keys($joinResult);
+        if ($this->getTargetFilter()) {
+            $filter = array_merge($connection->getMapper()->unmapFilter($this->getTargetReflection(), $this->getTargetFilter()), $filter);
+        }
         $targetQuery->setFilter($filter);
 
         $targetResult = $targetAdapter->execute($targetQuery);

--- a/src/Association/ManyToOne.php
+++ b/src/Association/ManyToOne.php
@@ -60,11 +60,14 @@ class ManyToOne extends Single
 
         $targetAdapter = $connection->getAdapter($this->targetReflection->getAdapterName());
 
-        $query = $targetAdapter->createSelect($this->getTargetResource());
+        $query = $targetAdapter->createSelect($this->getTargetResource(), $this->getTargetSelection());
 
         // Set target conditions
         $filter = $this->filter;
         $filter[$this->getTargetPrimaryKey()][Entity\Filter::EQUAL] = $primaryValues;
+        if ($this->getTargetFilter()) {
+            $filter = array_merge($connection->getMapper()->unmapFilter($this->getTargetReflection(), $this->getTargetFilter()), $filter);
+        }
         $query->setFilter($filter);
 
         $result = $targetAdapter->execute($query);

--- a/src/Association/OneToMany.php
+++ b/src/Association/OneToMany.php
@@ -40,7 +40,7 @@ class OneToMany extends Multi
 
         $query = $targetAdapter->createSelect(
             $this->getTargetResource(),
-            [],
+            $this->getTargetSelection(),
             $this->orderBy,
             $this->limit,
             $this->offset
@@ -49,6 +49,12 @@ class OneToMany extends Multi
         // Set target conditions
         $filter = $this->filter;
         $filter[$this->getReferencedKey()][Entity\Filter::EQUAL] = array_values($primaryValues);
+        if ($this->getTargetFilter()) {
+            $filter = array_merge(
+                $connection->getMapper()->unmapFilter($this->getTargetReflection(), $this->getTargetFilter()),
+                $filter
+            );
+        }
         $query->setFilter($filter);
 
         $result = $targetAdapter->execute($query);

--- a/src/Association/OneToOne.php
+++ b/src/Association/OneToOne.php
@@ -54,10 +54,16 @@ class OneToOne extends Single
     {
         $targetAdapter = $connection->getAdapter($this->targetReflection->getAdapterName());
 
-        $query = $targetAdapter->createSelect($this->getTargetResource());
+        $query = $targetAdapter->createSelect($this->getTargetResource(), $this->getTargetSelection());
 
         $filter = $this->filter;
         $filter[$this->getTargetPrimaryKey()][Entity\Filter::EQUAL] = $primaryValues;
+        if ($this->getTargetFilter()) {
+            $filter = array_merge(
+                $connection->getMapper()->unmapFilter($this->getTargetReflection(), $this->getTargetFilter()),
+                $filter
+            );
+        }
         $query->setFilter($filter);
 
         $result = $targetAdapter->execute($query);

--- a/src/Entity/Filter.php
+++ b/src/Entity/Filter.php
@@ -101,6 +101,9 @@ class Filter
                 }
 
                 if (!$reflection->hasProperty($name)) {
+                    if (strpos($name, '.' ) !== false) {
+                        continue;
+                    }
                     throw new Exception\FilterException(
                         "Undefined property name '" . $name . "' used in filter!"
                     );

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -275,12 +275,29 @@ class Mapper
                 $property = $reflection->getProperty($name);
                 $unmappedName = $property->getName(true);
 
+
                 foreach ($item as $modifier => $value) {
 
-                    $result[$unmappedName][$modifier] = $this->unmapValue(
-                        $property,
-                        $value
-                    );
+                    if ($property->getType() !== Reflection\Property::TYPE_ARRAY
+                        && in_array($modifier, [Filter::EQUAL, Filter::NOT], true)
+                        && is_array($value)
+                    ) {
+                        // IN/NOT IN cases
+
+                        $result[$unmappedName][$modifier] = [];
+                        foreach ($value as $key => $valueVal) {
+                            $result[$unmappedName][$modifier][$key] = $this->unmapValue(
+                                $property,
+                                $valueVal
+                            );
+                        }
+                    } else {
+
+                        $result[$unmappedName][$modifier] = $this->unmapValue(
+                            $property,
+                            $value
+                        );
+                    }
                 }
             }
         }

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -85,6 +85,10 @@ class Mapper
         } elseif ($property->getType() === Entity\Reflection\Property::TYPE_ENTITY) {
             // Entity
 
+            if ($value instanceof Entity && $property->hasOption(Entity\Reflection\Property::OPTION_MAP_FILTER)) {
+                // if value is entity created by filter don't map it again
+                return $value;
+            }
             return $this->mapEntity($property->getTypeOption(), $value);
         } elseif ($property->getType() === Entity\Reflection\Property::TYPE_DATETIME
             || $property->getType() === Entity\Reflection\Property::TYPE_DATE

--- a/src/Query.php
+++ b/src/Query.php
@@ -2,7 +2,10 @@
 
 namespace UniMapper;
 
+use UniMapper\Adapter\IQuery;
+use UniMapper\Adapter\IQueryWithJoins;
 use UniMapper\Exception\QueryException;
+use UniMapper\Query\Filterable;
 
 abstract class Query
 {
@@ -58,6 +61,29 @@ abstract class Query
         }
 
         return $result;
+    }
+    
+    protected function setQueryFilters($filter, IQuery $query, Connection $connection)
+    {
+        if ($filter) {
+            $query->setFilter(
+                $connection->getMapper()->unmapFilter(
+                    $this->entityReflection,
+                    $filter
+                )
+            );
+
+            if ($query instanceof IQueryWithJoins) {
+                $joins = $connection->getMapper()->unmapFilterJoins(
+                    $this->entityReflection,
+                    $filter
+                );
+
+                if ($joins) {
+                    $query->setJoins($joins);
+                }
+            }
+        }
     }
 
 }

--- a/src/Query/Count.php
+++ b/src/Query/Count.php
@@ -13,14 +13,9 @@ class Count extends \UniMapper\Query
         $query = $adapter->createCount(
             $this->entityReflection->getAdapterResource()
         );
-        if ($this->filter) {
-            $query->setFilter(
-                $connection->getMapper()->unmapFilter(
-                    $this->entityReflection,
-                    $this->filter
-                )
-            );
-        }
+        
+        $this->setQueryFilters($this->filter, $query, $connection);
+        
         return (int) $adapter->execute($query);
     }
 

--- a/src/Query/Delete.php
+++ b/src/Query/Delete.php
@@ -16,14 +16,7 @@ class Delete extends \UniMapper\Query
             $this->entityReflection->getAdapterResource()
         );
 
-        if ($this->filter) {
-            $query->setFilter(
-                $connection->getMapper()->unmapFilter(
-                    $this->entityReflection,
-                    $this->filter
-                )
-            );
-        }
+        $this->setQueryFilters($this->filter, $query, $connection);
 
         return (int) $adapter->execute($query);
     }

--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -62,14 +62,7 @@ class Select extends \UniMapper\Query
             $this->offset
         );
 
-        if ($this->filter) {
-            $query->setFilter(
-                $mapper->unmapFilter(
-                    $this->entityReflection,
-                    $this->filter
-                )
-            );
-        }
+        $this->setQueryFilters($this->filter, $query, $connection);
 
         if ($this->associations["local"]) {
             $query->setAssociations($this->associations["local"]);

--- a/src/Query/Update.php
+++ b/src/Query/Update.php
@@ -38,14 +38,8 @@ class Update extends \UniMapper\Query
             $this->entityReflection->getAdapterResource(),
             $values
         );
-        if ($this->filter) {
-            $query->setFilter(
-                $mapper->unmapFilter(
-                    $this->entityReflection,
-                    $this->filter
-                )
-            );
-        }
+        
+        $this->setQueryFilters($this->filter, $query, $connection);
 
         return (int) $adapter->execute($query);
     }

--- a/tests/cases/Entity.Filter.phpt
+++ b/tests/cases/Entity.Filter.phpt
@@ -333,6 +333,12 @@ class EntityFilterTest extends \Tester\TestCase
         Filter::validate(Reflection::load("Simple"), ["id" => [Filter::EQUAL => ["foo"]]]);
     }
 
+
+    public function testValidateNestedJoid()
+    {
+        Filter::validate(Reflection::load("Simple"), ["nested.id" => [Filter::EQUAL => ["foo"]]]);
+    }
+
 }
 
 $testCase = new EntityFilterTest;

--- a/tests/cases/Mapper.phpt
+++ b/tests/cases/Mapper.phpt
@@ -150,6 +150,20 @@ class MapperTest extends \Tester\TestCase
         );
     }
 
+    public function testUnmapFilterWithJoins()
+    {
+        $fooMapping = Mockery::mock('\UniMapper\Adapter\Mapping');
+        $fooMapping->shouldReceive('unmapFilterJoinProperty')->once()->andReturn('foo');
+        $this->mapper->registerAdapterMapping('FooAdapter', $fooMapping);
+        Assert::same(
+            ["foo" => [\UniMapper\Entity\Filter::EQUAL => 1]],
+            $this->mapper->unmapFilter(
+                Reflection::load("Simple"),
+                ["oneToOne.id" => [\UniMapper\Entity\Filter::EQUAL => 1]]
+            )
+        );
+    }
+
 }
 
 $testCase = new MapperTest;

--- a/tests/cases/Query.Select.phpt
+++ b/tests/cases/Query.Select.phpt
@@ -121,7 +121,7 @@ class QuerySelectTest extends \Tester\TestCase
             ->with(["id" => [\UniMapper\Entity\Filter::EQUAL => [3, 4]]])
             ->once();
         $this->adapters["RemoteAdapter"]->shouldReceive("createSelect")
-            ->with("remote_resource")
+            ->with("remote_resource", [])
             ->once()
             ->andReturn($this->adapterQueryMock);
         $this->adapters["RemoteAdapter"]->shouldReceive("onExecute")

--- a/tests/cases/Query.SelectOne.phpt
+++ b/tests/cases/Query.SelectOne.phpt
@@ -149,7 +149,7 @@ class QuerySelectOneTest extends \Tester\TestCase
             ->with(["id" => [\UniMapper\Entity\Filter::EQUAL => [2]]])
             ->once();
         $this->adapters["RemoteAdapter"]->shouldReceive("createSelect")
-            ->with("remote_resource")
+            ->with("remote_resource", [])
             ->once()
             ->andReturn($this->adapterQueryMock);
         $this->adapters["RemoteAdapter"]->shouldReceive("onExecute")


### PR DESCRIPTION
Adds posibility to use "joins" in query filters on associations. 

For example we have entity **One** with property **foo** witch is _oneToOne_ association to entity **Two**. Property name in filter will be **"foo.id"** 

If it so, then first property name is unmaped with custom adapter mapping _unmapFilterJoinProperty_ witch translate properties for example to columns. Then when query is executed and filters are about to be set through _setQueryFilters_ then, if query is instance of _IQueryWithJoins_, the filter is unmaped with _unmapFilterJoins_.

To enable this behavior is necessary that Query implements _IQueryWithJoins_ interface to proper set joins.

And Adapter should extend mapping _unmapFilterJoinProperty_ and _unmapFilterJoins_ for concrete mappings.
