### PR TITLE
Mapper: don't map entity if the result value is produced by filter

### DIFF
--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -96,6 +96,10 @@ class Mapper
         } elseif ($property->getType() === Entity\Reflection\Property::TYPE_ENTITY) {
             // Entity
 
+            if ($value instanceof Entity && $property->hasOption(Entity\Reflection\Property::OPTION_MAP_FILTER)) {
+                // if value is entity created by filter don't map it again
+                return $value;
+            }
             return $this->mapEntity($property->getTypeOption(), $value);
         } elseif ($property->getType() === Entity\Reflection\Property::TYPE_DATETIME
             || $property->getType() === Entity\Reflection\Property::TYPE_DATE


### PR DESCRIPTION
If entity property is Entity but with filters, which produce already Entity instance is not desirable to map it again (if it has some public properties filled it will disappears etc... )